### PR TITLE
parseConfigMapFromYamlNode: add proper checking of input filename

### DIFF
--- a/src/ConfigData.cpp
+++ b/src/ConfigData.cpp
@@ -56,6 +56,14 @@ namespace configmaps {
 
     ConfigMap ConfigMap::fromYamlFile(const string &filename, bool loadURI) {
       std::ifstream fin(filename.c_str());
+      if (!fin.good()) {
+          fprintf(stderr, "ERROR: ConfigMap::fromYamlFile failed! "
+                          "Could not open input file \"%s\"\n",
+                  filename.c_str());
+          // wouldn't it be better to throw? the returned map is empty, which
+          // might not be what the caller actually wants?
+          return ConfigMap();
+      }
       ConfigMap map = fromYamlStream(fin);
       if(loadURI) {
         std::string pathToFile = getPathOfFile(filename);


### PR DESCRIPTION
otherwise, it happily tries to parse nonexisting files. which should fail, and loudly so! meaning: throwing is even better than return an empty ConfigMap... But this would be the first throw in this class, so...?

I would change the commit into a throw.

Signed-off-by: Martin Zenzes martin.zenzes@dfki.de
