### PR TITLE
fix build/install on 18.04

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,7 +71,11 @@ install(TARGETS configmaps EXPORT configmaps-targets
 )
 
 # Install the library into the lib folder
-install(TARGETS configmaps ${_INSTALL_DESTINATIONS})
+install(TARGETS configmaps 
+  RUNTIME DESTINATION bin
+  LIBRARY DESTINATION ${LIB_INSTALL_DIR}
+  ARCHIVE DESTINATION lib
+)
 
 # Install headers into mars include directory
 install(FILES ${HEADERS} DESTINATION include/configmaps)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,13 +70,6 @@ install(TARGETS configmaps EXPORT configmaps-targets
   ARCHIVE DESTINATION lib
 )
 
-# Install the library into the lib folder
-install(TARGETS configmaps 
-  RUNTIME DESTINATION bin
-  LIBRARY DESTINATION ${LIB_INSTALL_DIR}
-  ARCHIVE DESTINATION lib
-)
-
 # Install headers into mars include directory
 install(FILES ${HEADERS} DESTINATION include/configmaps)
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -23,7 +23,7 @@ if(Catch_FOUND)
   catch_discover_tests(configmaps_test)
 endif()
 
-add_custom_target(test
+add_custom_target(run_test
     COMMAND ${CMAKE_CURRENT_BINARY_DIR}/configmaps_test
     DEPENDS configmaps
 )


### PR DESCRIPTION

    CMake Error at CMakeLists.txt:74 (install):
      install TARGETS given no LIBRARY DESTINATION for shared library target
      "configmaps".
    
    
    CMake Error at test/CMakeLists.txt:26 (add_custom_target):
      The target name "test" is reserved or not valid for certain CMake features,
      such as generator expressions, and may result in undefined behavior.
    
